### PR TITLE
Fix json flag when invoking CLI

### DIFF
--- a/src/lib/lightningLinter.ts
+++ b/src/lib/lightningLinter.ts
@@ -32,7 +32,7 @@ export class lightningLinter{
         dirPath = '"'+dirPath.substring(0,dirPath.length-1)+'"'
 
 
-        let cmd = ( (this._config.useSfdx) ? 'sfdx force:' : 'heroku ' ) + 'lightning:lint '+dirPath+' --files '+file+' -j';
+        let cmd = ( (this._config.useSfdx) ? 'sfdx force:' : 'heroku ' ) + 'lightning:lint '+dirPath+' --files '+file+' --json';
 
         this._outputChannel.appendLine('Linter Command: ' + cmd);
         //try {


### PR DESCRIPTION
Hi,

As of version `7.3.0` for sfdx, we have to use `--json` in order to get a JSON response from the CLI. Otherwise `vscode-lightning-linter` will throw this error:

```
ERROR running force:lightning:lint:  Unexpected argument: -j
```

I've installed the lastest heroku toolbelt plugin for Lightning Lint, and it follows the same format.